### PR TITLE
tissot: New build

### DIFF
--- a/builds/tissot.json
+++ b/builds/tissot.json
@@ -61,6 +61,11 @@
          "file_name":"PixelExperience_tissot-9.0-20181206-0546-OFFICIAL.zip",
          "file_size":1028299131,
          "md5":"5d89b670b0ae9746b02d381f86cbc95c"
+      },
+      {
+         "file_name":"PixelExperience_tissot-9.0-20181208-0658-OFFICIAL.zip",
+         "file_size":1028806949,
+         "md5":"85129136cc626d8f4b70fed6c77329ac"
       }
    ]
 }

--- a/changelog/tissot/PixelExperience_tissot-9.0-20181208-0658-OFFICIAL.txt
+++ b/changelog/tissot/PixelExperience_tissot-9.0-20181208-0658-OFFICIAL.txt
@@ -1,0 +1,8 @@
+* Upstream stock kernel to 4.9.143
+* Fix battery status issues caused by older kernel
+* Update vendor blobs from Official Pie update
+* Update vendor security patch level
+* Add missing libraries for IMS
+* Fix Wi-Fi symlink path
+* Remove Device is HD capable from persistent notification
+


### PR DESCRIPTION
Changelog:
* Upstream stock kernel to 4.9.143
* Fix battery status issues caused by older kernel
* Update vendor blobs from Official Pie update
* Update vendor security patch level
* Add missing libraries for IMS
* Fix Wi-Fi symlink path
* Remove Device is HD capable from persistent notification