### PR TITLE
tissot: New build

### DIFF
--- a/builds/tissot.json
+++ b/builds/tissot.json
@@ -81,6 +81,11 @@
          "file_name":"PixelExperience_tissot-9.0-20181211-1038-OFFICIAL.zip",
          "file_size":1028812201,
          "md5":"01b097e297fa16b2ecf647cf372d0670"
+      },
+      {
+         "file_name":"PixelExperience_tissot-9.0-20181216-1559-OFFICIAL.zip",
+         "file_size":1031545737,
+         "md5":"5c4cf2dfd56e82479cedcd59a8c6e9b0"
       }
    ]
 }

--- a/changelog/tissot/PixelExperience_tissot-9.0-20181216-1559-OFFICIAL-Changelog.txt
+++ b/changelog/tissot/PixelExperience_tissot-9.0-20181216-1559-OFFICIAL-Changelog.txt
@@ -1,0 +1,19 @@
+=======================
+     12-17-2018
+=======================
+
+
+   * device/xiaomi/msm8953-common/
+cf4d8d9 msm8953-common: Include Wfd changes
+38ebf63 msm8953-common: Update properties from tissot PKQ1.180917.001
+64c9b6f msm8953-common: Re-apply 3d8188b
+1cd87ce msm8953-common: sepolicy: Address keydisabler denials
+d3d7383 msm8953-common: Update sepolicy for P, take 2
+50d48ad msm8953-common: Update sepolicy for P
+
+   * device/xiaomi/tissot/
+cd0e775 tissot: Pin pre-P acdbdata and FPC fingerprint blobs
+972497d tissot: audio: Update from PKQ1.180917.001
+
+   * vendor/xiaomi/
+f9a8cd1 tissot: Restore pre-P acdbdata and FPC blobs


### PR DESCRIPTION
- Revert to FPC pre-Pie files
- Upstream kernel to 4.9.145
- Under the hood blob changes