### PR TITLE
mido: 20190124 Update

### DIFF
--- a/builds/mido.json
+++ b/builds/mido.json
@@ -21,7 +21,11 @@
          "file_name":"PixelExperience_mido-9.0-20190119-0445-OFFICIAL.zip",
          "file_size":949560632,
          "md5":"a963af6960cdb6aeb77b66d6706eb6e3"
+      },
+      {
+         "file_name":"PixelExperience_mido-9.0-20190124-0748-OFFICIAL.zip",
+         "file_size":946643841,
+         "md5":"ec710e13f01de944b2a6c8706e2e49fd"
       }
-
    ]
 }

--- a/changelog/mido/PixelExperience_mido-9.0-20190124-0748-OFFICIAL.txt
+++ b/changelog/mido/PixelExperience_mido-9.0-20190124-0748-OFFICIAL.txt
@@ -1,0 +1,17 @@
+* Fixed Dirac Crash (Blobs Still Messed Up)
+* Fixed Low Audio Issues 
+* System Wide Black Theme Implementation From Q 
+* Notification Themed 
+* Updated Xiaomi Doze From sdm845 
+* Updated AdvancedControls 
+* Added Fast Wake Patch With Toggle (Wont Work on Enforcing U Need to Flash Permissive Patcher) 
+* Changed Kernel To Englezos Kernel 
+* Updated SDM Blobs From Latest Caf Tag LA.UM.7.6.r1-03900-89xx.0
+* Back To Mido Build Fingerprint 
+* Added NavBar Finnally lol 
+* Much More UnderHood Changes 
+* Removed wcnss filters
+* Updated Blobs To Tissot latest update
+
+Thx @WEareGROOOT @sumon008 @CakeSpJ993 @danielh1402  anonimo @ozark1 @Techniroy_sama  for testings
+


### PR DESCRIPTION
* Fixed Dirac Crash (Blobs Still Messed Up)
* Fixed Low Audio Issues 
* System Wide Black Theme Implementation From Q 
* Notification Themed 
* Updated Xiaomi Doze From sdm845 
* Updated AdvancedControls 
* Added Fast Wake Patch With Toggle (Wont Work on Enforcing U Need to Flash Permissive Patcher) 
* Changed Kernel To Englezos Kernel 
* Updated SDM Blobs From Latest Caf Tag LA.UM.7.6.r1-03900-89xx.0
* Back To Mido Build Fingerprint 
* Added NavBar Finnally lol 
* Much More UnderHood Changes 
* Removed wcnss filters
* Updated Blobs To Tissot latest update