### PR TITLE
harpia: Update 11 April, 2019

### DIFF
--- a/builds/harpia.json
+++ b/builds/harpia.json
@@ -26,6 +26,11 @@
          "file_name": "PixelExperience_harpia-9.0-20190320-1108-OFFICIAL.zip",
          "file_size": 749410020,
          "md5": "cc9d60be5cffc352e8af6b9e8fa80724"
+      },
+      {
+         "file_name": "PixelExperience_harpia-9.0-20190411-0147-OFFICIAL.zip",
+         "file_size": 749763370,
+         "md5": "3a29ab2df7e0d8388d3be184c95ee0de"
       }
    ]
 }

--- a/changelog/harpia/PixelExperience_harpia-9.0-20190411-0147-OFFICIAL.txt
+++ b/changelog/harpia/PixelExperience_harpia-9.0-20190411-0147-OFFICIAL.txt
@@ -1,0 +1,21 @@
+* April sec patch
+
+* Pie perf stack
+
+* Update thermal config for cluster0 and camera
+
+* Update init.mmi.touch.sh
+
+* Update audio configs from stock
+
+* Use old picker and prevent it from updating
+
+* Update ril blobs from athene
+
+* Dark theme fixes in some apps
+
+* Boot time improved
+
+* Fixup BT mac address
+
+* Added more ims props


### PR DESCRIPTION
* April sec patch

* Pie perf stack

* Update thermal config for cluster0 and camera

* Update init.mmi.touch.sh

* Update audio configs from stock

* Use old picker and prevent it from updating

* Update ril blobs from athene

* Dark theme fixes in some apps

* Boot time improved

* Fixup BT mac address

* Added more ims props