### PR TITLE
land: AOSP/CAF June update

### DIFF
--- a/builds/land.json
+++ b/builds/land.json
@@ -46,6 +46,11 @@
          "file_name": "PixelExperience_land-9.0-20190508-1437-OFFICIAL.zip",
          "file_size": 970932286,
          "md5": "84c684173f5866a2eca3b4262ceb0f3c"
+      },
+      {
+  	 "file_name": "PixelExperience_land-9.0-20190608-0407-OFFICIAL.zip",
+  	 "file_size": 976502323,
+  	 "md5": "53d4400626f099c211192c48a99389be"
       }
    ],
    "pie_caf": [
@@ -68,6 +73,11 @@
   	 "file_name": "PixelExperience_caf_land-9.0-20190512-0652-OFFICIAL.zip",
   	 "file_size": 973665312,
   	 "md5": "41a919b015b8672db22474437889bdd0"
+      },
+      {
+  	 "file_name": "PixelExperience_caf_land-9.0-20190608-0934-OFFICIAL.zip",
+  	 "file_size": 980738731,
+  	 "md5": "5dc81604cdfc4b45de271754fb376132"
       }
    ]
 }

--- a/changelog/land/PixelExperience_caf_land-9.0-20190608-0934-OFFICIAL.txt
+++ b/changelog/land/PixelExperience_caf_land-9.0-20190608-0934-OFFICIAL.txt
@@ -1,0 +1,6 @@
+Changelog:
+• Added MI Sound (CAF).
+• Enabled Adaptive Brightness by default.
+• Some minor optimizations.
+• Kernel upstreamed to 3.18.140
+• Merged latest CAF tg into kernel.

--- a/changelog/land/PixelExperience_land-9.0-20190608-0407-OFFICIAL.txt
+++ b/changelog/land/PixelExperience_land-9.0-20190608-0407-OFFICIAL.txt
@@ -1,0 +1,6 @@
+Changelog:
+
+• Enabled Adaptive Brightness by default.
+• Some minor optimizations.
+• Kernel upstreamed to 3.18.140
+• Merged latest CAF tg into kernel.


### PR DESCRIPTION
Device: land
AOSP & CAF
Changelog:
• Added MI Sound (CAF).
• Enabled Adaptive Brightness by default.
• Some minor optimizations.
• Kernel upstreamed to 3.18.140
• Merged latest CAF tg into kernel.