### PR TITLE
montana: June update (CAF)

### DIFF
--- a/builds/montana.json
+++ b/builds/montana.json
@@ -41,6 +41,11 @@
          "file_name": "PixelExperience_caf_montana-9.0-20190514-0855-OFFICIAL.zip",
          "file_size": 827401066,
          "md5": "0c05d21a35da6d243aeadeba2637ca2d"
+      },
+      {
+         "file_name": "PixelExperience_caf_montana-9.0-20190617-2113-OFFICIAL.zip",
+         "file_size": 784418734,
+         "md5": "759b6fc61f63876ace49c66aa8b6432b"
       }
    ]
 }

--- a/changelog/montana/PixelExperience_caf_montana-9.0-20190617-2113-OFFICIAL.txt
+++ b/changelog/montana/PixelExperience_caf_montana-9.0-20190617-2113-OFFICIAL.txt
@@ -1,0 +1,18 @@
+Device side changes:
+- Removed NFC for XT1795.
+- Fixed Wi-Fi Display (Miracast).
+- Fixed Google Camera mod crash.
+- Updated some media codecs.
+- Updated device fingerprint to June security patch.
+
+ROM side changes:
+- June security patch.
+- Network traffic indicator improved.
+- Fixed force crash on some devices when connecting to Bluetooth headset
+- Theming improvements: Added black theme (enabled by default on devices that have OLED screens), disabled dark theme when battery saver enabled (for devices that have LCD screens) and others
+- Improved behavior of automatic theme based on time
+- Pixel Launcher and some others apps updated
+- Translations updated
+- Font improvements
+- Fixed vibration on incoming calls
+- Other fixes


### PR DESCRIPTION
Device: montana
Edition: CAF
Device changes:
- Removed NFC for XT1795.
- Fixed Wi-Fi Display (Miracast).
- Fixed Google Camera mod crash.
- Updated some media codecs.
- Updated device fingerprint to June security patch. 