### PR TITLE
montana: 06/18 update (CAF)

### DIFF
--- a/builds/montana.json
+++ b/builds/montana.json
@@ -46,6 +46,11 @@
          "file_name": "PixelExperience_caf_montana-9.0-20190617-2113-OFFICIAL.zip",
          "file_size": 784418734,
          "md5": "759b6fc61f63876ace49c66aa8b6432b"
+      },
+      {
+         "file_name": "PixelExperience_caf_montana-9.0-20190618-1515-OFFICIAL.zip",
+         "file_size": 830701441,
+         "md5": "efc29ed7606b62d6e8d5e1e8781d348d"
       }
    ]
 }

--- a/changelog/montana/PixelExperience_caf_montana-9.0-20190618-1515-OFFICIAL.txt
+++ b/changelog/montana/PixelExperience_caf_montana-9.0-20190618-1515-OFFICIAL.txt
@@ -1,0 +1,2 @@
+- Switched back to Google Camera Mod
+- Switched back to stock kernel


### PR DESCRIPTION
Device: montana
Edition: CAF
Device changes:
* Switched back to Google Camera Mod
* Switched back to stock kernel