### PR TITLE
montana: 06/23 update (CAF)

### DIFF
--- a/builds/montana.json
+++ b/builds/montana.json
@@ -52,5 +52,10 @@
          "file_size": 830701441,
          "md5": "efc29ed7606b62d6e8d5e1e8781d348d"
       }
+      {
+         "file_name": "PixelExperience_caf_montana-9.0-20190622-0638-OFFICIAL.zip",
+         "file_size": 830816124,
+         "md5": "5a61418b25417ccf84763b7b2bba98a7"
+      }
    ]
 }

--- a/changelog/montana/PixelExperience_caf_montana-9.0-20190623-0638-OFFICIAL.txt
+++ b/changelog/montana/PixelExperience_caf_montana-9.0-20190623-0638-OFFICIAL.txt
@@ -1,0 +1,6 @@
+- Added rounded corners
+- Switched to payton's fingerprint (now passes SafetyNet)
+- Smoothened vibrations
+- Fixed video recording (now works reliably)
+- Updated display blobs
+- Updated AptX blobs


### PR DESCRIPTION
Device: montana
Edition: CAF
Device changes:
* Added rounded corners
* Switched to payton's fingerprint (now passes SafetyNet)
* Smoothened vibrations
* Fixed video recording (now works reliably)
* Updated display blobs
* Updated AptX blobs