### PR TITLE
Add Sony Tama Platform

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1103,6 +1103,48 @@
       ]
    },
    {
+      "name": "Xperia XZ3",
+      "brand": "Sony",
+      "codename": "Akatsuki",
+      "supported_versions": [
+         {
+            "version_code": "ten",
+            "version_name": "10",
+            "maintainer_name": "AngeloGioacchino Del Regno (kholk), Paul Bouchara (Redkaled)",
+            "maintainer_url": "https://github.com/paulbouchara",
+            "xda_thread": ""
+         }
+      ]
+   },
+      {
+      "name": "Xperia XZ2",
+      "brand": "Sony",
+      "codename": "Akari",
+      "supported_versions": [
+         {
+            "version_code": "ten",
+            "version_name": "10",
+            "maintainer_name": "AngeloGioacchino Del Regno (kholk), Paul Bouchara (Redkaled)",
+            "maintainer_url": "https://github.com/paulbouchara",
+            "xda_thread": ""
+         }
+      ]
+   },
+      {
+      "name": "Xperia XZ2 Compact",
+      "brand": "Sony",
+      "codename": "Apollo",
+      "supported_versions": [
+         {
+            "version_code": "ten",
+            "version_name": "10",
+            "maintainer_name": "AngeloGioacchino Del Regno (kholk), Paul Bouchara (Redkaled)",
+            "maintainer_url": "https://github.com/paulbouchara",
+            "xda_thread": ""
+         }
+      ]
+   },
+   {
       "name": "Mi 6X",
       "brand": "Xiaomi",
       "codename": "wayne",


### PR DESCRIPTION
Here is the first roster of devices, the following platforms will come later after getting a DD experience on the tama platform
Following platforms :
- Kumano (2 devices)
- Yoshino (3 devices)
- Ganges (2 devices)
- Nile (3 devices)
- Tone (3 devices)
- Loire (2 devices)