### PR TITLE
PixelExperience : Drop Mi A2

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -805,36 +805,6 @@
       ]
    },
    {
-      "name": "Mi A2",
-      "brand": "Xiaomi",
-      "codename": "jasmine_sprout",
-      "supported_versions": [
-         {
-            "version_code": "ten",
-            "version_name": "10",
-            "maintainer_name": "Aryan Gupta",
-            "maintainer_url": "https://forum.xda-developers.com/member.php?u=7515368",
-            "xda_thread": "https://forum.xda-developers.com/mi-a2/development/rom-pixel-experience-t3968163"
-         },
-         {
-            "version_code": "pie",
-            "version_name": "Pie",
-            "maintainer_name": "Aryan Gupta",
-            "maintainer_url": "https://forum.xda-developers.com/member.php?u=7515368",
-            "xda_thread": "https://forum.xda-developers.com/mi-a2/development/rom-pixel-experience-t3955704",
-            "deprecated": true
-         },
-         {
-            "version_code": "pie_plus",
-            "version_name": "Pie (Plus edition)",
-            "maintainer_name": "Aryan Gupta",
-            "maintainer_url": "https://forum.xda-developers.com/member.php?u=7515368",
-            "xda_thread": "https://forum.xda-developers.com/mi-a2/development/rom-pixel-experience-t3955704",
-            "deprecated": true
-         }
-      ]
-   },
-   {
       "name": "Mi 8 Lite",
       "brand": "Xiaomi",
       "codename": "platina",


### PR DESCRIPTION
Due to the release of 13/02/2020 where all the sensors for the device were broken, then the quote by aryan where he said "I don't support wired headphones" (Which you can see here https://imgur.com/IQ2WnRH and here https://t.me/pixeljasmine/44603) I think that he doesn't deserve to be the maintainer of PixelExperience. Also OTA Updates aren't working which is a big issue for people who aren't rooted and for people who don't have TWRP Installed. And then there's the issue of phone's getting stuck with the data corrupt error.