### PR TITLE
Sony : Add PE 11 to Sony devices

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -467,6 +467,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -482,6 +486,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -497,6 +505,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -512,6 +524,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -527,6 +543,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -623,6 +643,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -638,6 +662,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -653,6 +681,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -668,6 +700,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -683,6 +719,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -698,6 +738,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -713,6 +757,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -728,6 +776,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -743,6 +795,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -758,6 +814,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -773,6 +833,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -788,6 +852,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -848,6 +916,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -863,6 +935,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -878,6 +954,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -893,6 +973,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -938,6 +1022,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -953,6 +1041,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -968,6 +1060,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -983,6 +1079,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         { 
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -1625,6 +1725,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    },
@@ -1640,6 +1744,10 @@
          {
             "version_code": "ten_plus",
             "xda_thread": ""
+         },
+         {
+            "version_code": "eleven",
+            "stable": "false"
          }
       ]
    }

--- a/team/maintainers.json
+++ b/team/maintainers.json
@@ -40,189 +40,217 @@
             "codename": "j8210",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "j9210",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
+
             ]
          },
          {
             "codename": "j8110",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "j9110",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8416",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h9436",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8216",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8266",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8314",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8324",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i3213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i4213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i3113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i4113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3413",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4413",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8341",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8342",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8441",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8141",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8142",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "xqau51",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "xqau52",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          }
       ]
@@ -671,189 +699,216 @@
             "codename": "j8210",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "j9210",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "j8110",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "j9110",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8416",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h9436",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8216",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8266",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8314",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h8324",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i3213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i4213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i3113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "i4113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3413",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4413",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4213",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h3113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "h4113",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8341",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8342",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8441",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8141",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "g8142",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "xqau51",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          },
          {
             "codename": "xqau52",
             "versions": [
                "ten",
-               "ten_plus"
+               "ten_plus",
+               "eleven"
             ]
          }
       ]


### PR DESCRIPTION
We were ready for this since AOSP 11 is out, now just waiting to rip the CI.