### PR TITLE
Make twelve stable for cheeseburger and dumpling

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -826,7 +826,7 @@
          },
          {
             "version_code": "twelve",
-            "stable": false,
+            "stable": true,
             "xda_thread": "https://forum.xda-developers.com/t/beta-12-0-pixel-experience-12-oneplus-5-5t-dumpling-cheeseburger.4351697/",
             "deprecated": false
          }

--- a/devices.json
+++ b/devices.json
@@ -649,7 +649,7 @@
          },
          {
             "version_code": "twelve",
-            "stable": false,
+            "stable": true,
             "xda_thread": "https://forum.xda-developers.com/t/beta-12-0-pixel-experience-12-oneplus-5-5t-dumpling-cheeseburger.4351697/",
             "deprecated": false
          }


### PR DESCRIPTION
SELINUX ENFORCING
https://github.com/PixelExperience-Devices/device_oneplus_msm8998-common/commit/e654fb95bb1dee7b5f5149c3d1487fb5e4ec51f3

DT
https://github.com/PixelExperience-Devices/device_oneplus_msm8998-common/tree/twelve
https://github.com/PixelExperience-Devices/device_oneplus_cheeseburger/tree/twelve
https://github.com/PixelExperience-Devices/device_oneplus_dumpling/tree/twelve

VENDOR
https://gitlab.pixelexperience.org/android/vendor-blobs/vendor_oneplus_msm8998-common/-/tree/twelve
https://gitlab.pixelexperience.org/android/vendor-blobs/vendor_oneplus_cheeseburger/-/tree/twelve
https://gitlab.pixelexperience.org/android/vendor-blobs/vendor_oneplus_dumpling/-/tree/twelve

KERNEL
https://github.com/PixelExperience-Devices/kernel_oneplus_msm8998/tree/twelve