### PR TITLE
Update alioth to include Poco F3 and Redmi K40

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -261,7 +261,7 @@
       ]
    },
    {
-      "name": "Mi 11X",
+      "name": "Mi 11X/Redmi K40/Poco F3",
       "brand": "Xiaomi",
       "codename": "alioth",
       "supported_versions": [


### PR DESCRIPTION
This should hopefully reduce confusion with this particular phone (they all use the same codename and to the best of my knowledge the builds available work on the Poco F3 despite being labelled for the Mi 11X but it may be an issue with other Xiaomi phones - for example the Redmi K30S uses the same codename as the Mi 10T (apollo) - however I can't be sure that the available builds for the Mi 10T will work on the K30S since I don't own one.

Do I need to edit anywhere else?

Thanks :)