### PR TITLE
marlin/sailfish: remove twelve

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1417,11 +1417,6 @@
             "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-marlin-pixelexperience-aosp-official.4247199/",
             "stable": true,
             "deprecated": true
-         },
-         {
-            "version_code": "twelve",
-            "stable": false,
-            "deprecated": false
          }
       ],
       "repositories": [
@@ -2014,11 +2009,6 @@
             "xda_thread": "https://forum.xda-developers.com/t/rom-11-0-sailfish-pixelexperience-aosp-official.4247201/",
             "stable": true,
             "deprecated": true
-         },
-         {
-            "version_code": "twelve",
-            "stable": false,
-            "deprecated": false
          }
       ],
       "repositories": [

--- a/devices.json
+++ b/devices.json
@@ -2476,5 +2476,39 @@
          "vendor_xiaomi_whyred",
          "vendor_xiaomi_sdm660-common"
       ]
+   },
+   {
+      "name": "Pixel 4",
+      "brand": "Google",
+      "codename": "flame",
+      "supported_versions": [
+         {
+            "version_code": "twelve",
+            "stable": true,
+            "deprecated": false
+         }
+      ],
+      "repositories": [
+         "device_google_coral",
+         "kernel_google_msm-4.14",
+         "vendor_google_flame"
+      ]
+   },
+   {
+      "name": "Pixel 4 XL",
+      "brand": "Google",
+      "codename": "coral",
+      "supported_versions": [
+         {
+            "version_code": "twelve",
+            "stable": true,
+            "deprecated": false
+         }
+      ],
+      "repositories": [
+         "device_google_coral",
+         "kernel_google_msm-4.14",
+         "vendor_google_coral"
+      ]
    }
 ]

--- a/team/maintainers.json
+++ b/team/maintainers.json
@@ -486,6 +486,18 @@
             "versions": [
                "twelve"
             ]
+         },
+         {
+            "codename": "flame",
+            "versions": [
+               "twelve"
+            ]
+         },
+         {
+            "codename": "coral",
+            "versions": [
+               "twelve"
+            ]
          }
       ],
       "ci_username": "pixelboot"

--- a/team/maintainers.json
+++ b/team/maintainers.json
@@ -476,18 +476,6 @@
       "telegram_url": "https://t.me/PixelBoot",
       "devices": [
          {
-            "codename": "sailfish",
-            "versions": [
-               "twelve"
-            ]
-         },
-         {
-            "codename": "marlin",
-            "versions": [
-               "twelve"
-            ]
-         },
-         {
             "codename": "walleye",
             "versions": [
                "twelve"


### PR DESCRIPTION
Will run 3.18 which is unsupported anyways, so just end support here.

This reverts commit fdf823c64730e256b842eb741d0bbaa860515ade.