### PR TITLE
Add Redmi K40 & POCO F3 to alioth's device name

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -247,7 +247,7 @@
       ]
    },
    {
-      "name": "Mi 11X",
+      "name": "Redmi K40/Poco F3/Mi 11X",
       "brand": "Xiaomi",
       "codename": "alioth",
       "supported_versions": [


### PR DESCRIPTION
- Same device, plus multiple people were asking if Mi 11X builds work on their K40 or F3.