### PR TITLE
alioth: Add dependency on firmware repo

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -323,7 +323,8 @@
          "device_xiaomi_sm8250-extras",
          "kernel_xiaomi_sm8250",
          "vendor_xiaomi_alioth",
-         "vendor_xiaomi_sm8250-common"
+         "vendor_xiaomi_sm8250-common",
+         "vendor_xiaomi-firmware"
       ]
    },
    {


### PR DESCRIPTION
Future builds for alioth will depend on MIUI 13 firmware. It's better to have future builds automatically flash the required firmware instead of making users do it themselves. Therefore, make the xiaomi firmware repository a dependency for alioth.