### PR TITLE
Add wiki blobs repo for alioth

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -324,7 +324,8 @@
          "kernel_xiaomi_sm8250",
          "vendor_xiaomi_alioth",
          "vendor_xiaomi_sm8250-common",
-         "vendor_xiaomi-firmware"
+         "vendor_xiaomi-firmware",
+         "wiki_blobs_alioth"
       ]
    },
    {


### PR DESCRIPTION
Starting with the August builds, the vendor_boot partition will need to be flashed on new installations. Create a wiki blobs repository to store the image.