### PR TITLE
official_devices: Drop gauguin

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1304,13 +1304,13 @@
             "version_code": "twelve",
             "xda_thread": "https://forum.xda-developers.com/t/rom-12-gauguin-official-pixel-experience-12-mi-10t-lite-mi-10i-redmi-note-9-pro-5g.4352869/",
             "stable": true,
-            "deprecated": false
+            "deprecated": true
          },
          {
             "version_code": "twelve_plus",
             "xda_thread": "https://forum.xda-developers.com/t/rom-12-gauguin-official-pixel-experience-12-mi-10t-lite-mi-10i-redmi-note-9-pro-5g.4352869/",
             "stable": true,
-            "deprecated": false
+            "deprecated": true
          }
       ],
       "repositories": [

--- a/team/maintainers.json
+++ b/team/maintainers.json
@@ -472,13 +472,6 @@
       "telegram_url": "http://t.me/LynnrinChan",
       "devices": [
          {
-            "codename": "gauguin",
-            "versions": [
-               "twelve",
-               "twelve_plus"
-            ]
-         },
-         {
             "codename": "blueline",
             "versions": [
                "twelve",


### PR DESCRIPTION
Due to some reason, I prefer close source gauguin's tree so I'll drop official support.