### PR TITLE
Revert "official_devices: Drop merlinx support (#2811)"

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -2318,7 +2318,7 @@
          {
             "version_code": "thirteen",
             "stable": false,
-            "deprecated": true
+            "deprecated": false
          }
       ],
       "repositories": [

--- a/team/maintainers.json
+++ b/team/maintainers.json
@@ -514,6 +514,22 @@
       "ci_username": "maluueu"
    },
    {
+      "name": "Matsvei Niaverau",
+      "country": "BY",
+      "github_username": "surblazer",
+      "xda_url": "https://forum.xda-developers.com/m/ud4.5213841/",
+      "telegram_url": "https://t.me/surblazer",
+      "devices": [
+         {
+            "codename": "merlinx",
+            "versions": [
+               "thirteen"
+            ]
+         }
+      ],
+      "ci_username": "surblazer"
+   },
+   {
       "name": "Nicholas Magill",
       "country": "GB",
       "github_username": "inkypen79",


### PR DESCRIPTION
* Well, a fix for Play Protect issue has been found

This reverts commit 2020992377cf377f1a86516689d76326a76b767e.