### PR TITLE
official_devices: Remove Redmi Note 11E Pro for now and update XDA thread URL

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -4230,7 +4230,7 @@
       ]
    },
    {
-      "name": "POCO X4 Pro 5G / Redmi Note 11E Pro / Redmi Note 11 Pro 5G / Redmi Note 11 Pro+ 5G",
+      "name": "POCO X4 Pro 5G / Redmi Note 11 Pro 5G / Redmi Note 11 Pro+ 5G",
       "brand": "Xiaomi",
       "codename": "veux",
       "supported_versions": [

--- a/devices.json
+++ b/devices.json
@@ -4236,11 +4236,13 @@
       "supported_versions": [
          {
             "version_code": "thirteen",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-13-veux-pixelexperience-aosp.4557537/",
             "stable": true,
             "deprecated": false
          },
          {
             "version_code": "thirteen_plus",
+            "xda_thread": "https://forum.xda-developers.com/t/rom-13-veux-pixelexperience-aosp.4557537/",
             "stable": true,
             "deprecated": false
          }


### PR DESCRIPTION
Redmi Note 11E Pro hasn't properly supported since the NFC still broken due to different stack usage.