### PR TITLE
RMX2061: move sm7125-common blobs to a seperate repo

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -142,7 +142,8 @@
          "device_realme_RMX2061",
          "device_realme_sm7125-common",
          "kernel_realme_sm7125",
-         "vendor_realme_RMX2061"
+         "vendor_realme_RMX2061",
+	 "vendor_realme_sm7125-common"
       ]
    },
    {


### PR DESCRIPTION
making way for rmx2170 builds