### PR TITLE
martini: Add vendor_oneplus-firmware for martini

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -2931,6 +2931,7 @@
       "repositories": [
          "device_oneplus_martini",
          "vendor_oneplus_martini",
+         "vendor_oneplus-firmware",
          "kernel_oneplus_martini",
          "wiki_blobs_martini"
       ]


### PR DESCRIPTION
Time to ship with fw, because apparently users don't read instruction.