### PR TITLE
Mark `fog` (Redmi 10 / 10C / 10 Power) as deprecated

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1870,14 +1870,14 @@
          {
             "version_code": "thirteen",
             "xda_thread": "",
-            "stable": true,
-            "deprecated": false
+            "stable": false,
+            "deprecated": true
          },
          {
             "version_code": "thirteen_plus",
             "xda_thread": "",
-            "stable": true,
-            "deprecated": false
+            "stable": false,
+            "deprecated": true
          }
       ],
       "repositories": [


### PR DESCRIPTION
The last commit in the `device_xiaomi_fog` repository was on April 8.